### PR TITLE
Client: fix stop behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ When the client runs out of buffers to store frames, it will continue receiving 
 If the connection is disconnected or if the client detects a protocol error, it will try to reconnect the stream automatically.
 If the client receives a frame that is larger than the destination buffer, the frame will be discarded.
 
+The client can be stopped via its stop() method:
+```
+client.stop()
+```
+
+If the client shall be restarted after calling stop() one must create a new instance as threads can only be started once:
+```
+# Create a new client thread
+client = MJPEGClient(url)
+``` 
+
 The client provides a method called `print_stats` which can be used for debugging:
 ```
 MJPEGClient:

--- a/mjpeg/client.py
+++ b/mjpeg/client.py
@@ -54,6 +54,9 @@ class MJPEGClient(Thread):
         self.daemon = True
         self._incoming = deque()
         self._outgoing = Queue()
+        
+        # Internal variable used to control internal processing loops
+        self._stop_loops = False
 
         # Keep track of the total number of overruns in this attribute
         self.overruns = 0
@@ -69,7 +72,7 @@ class MJPEGClient(Thread):
         self.discarded_frames = 0
 
     def stop(self):
-        self.stop = True
+        self._stop_loops = True
 
     def request_buffers(self, length, count):
         rv = []
@@ -142,10 +145,10 @@ class MJPEGClient(Thread):
         print('  Buffer queue    : %d' % len(self._incoming))
 
     def run(self):
-        self.stop = False
+        self._stop_loops = False
         self._init_fps()
 
-        while not self.stop:
+        while not self._stop_loops:
             try:
                 with urllib.request.urlopen(self.url) as s:
                     self.process_stream(s)

--- a/mjpeg/client.py
+++ b/mjpeg/client.py
@@ -106,7 +106,7 @@ class MJPEGClient(Thread):
         boundary = open_mjpeg_stream(stream)
         seq = 0
 
-        while True:
+        while not self._stop_loops:
             try:
                 buf = self._incoming.pop()
                 mem = buf.data


### PR DESCRIPTION
In the current release, the client can not be stopped via calling `client.stop()` as the loop within the `process_stream()` method has no stop condition.
This PR fixes the behavior by using the stop variable as a condition for the while loop.