### PR TITLE
Handle incorrect boundary reported in headers

### DIFF
--- a/mjpeg/__init__.py
+++ b/mjpeg/__init__.py
@@ -108,6 +108,12 @@ def check_content_type(headers, type_):
 
     return True
 
+def check_boundary_string(boundary: str) -> str:
+    result = boundary
+    if boundary.startswith('----'):
+        result = boundary[2:]
+    return result
+
 
 def open_mjpeg_stream(stream):
     '''Open an MJPEG stream.
@@ -124,6 +130,7 @@ def open_mjpeg_stream(stream):
     if boundary is None:
         raise ProtoError('Content-Type header does not provide boundary string')
     boundary = '--' + boundary
+    boundary = check_boundary_string(boundary)
 
     return boundary
 

--- a/mjpeg/__init__.py
+++ b/mjpeg/__init__.py
@@ -109,10 +109,9 @@ def check_content_type(headers, type_):
     return True
 
 def check_boundary_string(boundary: str) -> str:
-    result = boundary
-    if boundary.startswith('----'):
-        result = boundary[2:]
-    return result
+    if not boundary.startswith('--'):
+        return '--' + boundary
+    return boundary
 
 
 def open_mjpeg_stream(stream):
@@ -129,7 +128,6 @@ def open_mjpeg_stream(stream):
     boundary = h.get_param('boundary', header='content-type', unquote=True)
     if boundary is None:
         raise ProtoError('Content-Type header does not provide boundary string')
-    boundary = '--' + boundary
     boundary = check_boundary_string(boundary)
 
     return boundary


### PR DESCRIPTION
Some MJPEG implementations I've tested against report their `boundary` delimiters with the two hyphens included:

```
Content-Type': 'multipart/x-mixed-replace; boundary=--myboundary
```

with the line
```
--myboundary
```

being used as the delimiter.  While this is incorrect behavior according to [RFC 2046](https://www.rfc-editor.org/rfc/rfc2046#section-5.1.1), it would still seem appropriate to correct for it.

I've tested against a Panasonic HE40 PTZ camera as well as a few "mjpeg public test streams" I've found through searches and this behavior seems to be fairly common.